### PR TITLE
[k8s-user]: use token in kubeconfig and add service account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ examples/**/.terraform.lock.hcl
 clients/*
 
 .DS_Store
+.idea

--- a/modules/k8s-user/templates/kubeconfig.tmpl
+++ b/modules/k8s-user/templates/kubeconfig.tmpl
@@ -18,3 +18,4 @@ users:
   user:
     client-certificate-data: ${client_certificate}
     client-key-data: ${client_key}
+    token: ${client_token}


### PR DESCRIPTION
- Add service_account
- Use `_v1` Kubernetes resources 
- add token in kubeconfig
- store token near with kubeconfig

Signed-off-by: Igor Churmeev <ichurmeev@makezbs.com>